### PR TITLE
fix: Incorrect no. of participants in example 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ vatPercentage = 0.2
 Input                          Output
 -----------------------        ------------------------
 Reward = £100                  totalCost = £72,500
-Number of Participants = 50    rewardPerHour = £30/hr
+Number of Participants = 500    rewardPerHour = £30/hr
 Time = 200 minutes
 feesPercentage = 0.4
 vatPercentage = 0.125


### PR DESCRIPTION
Not sure how I've never noticed this but it really derailed an interview just now, I thought I was going mad!

It's already correct in the vue repo